### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -16,7 +16,7 @@ fontType_t	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
+begin	KEYWORD2
 control	KEYWORD2
 getDeviceCount	KEYWORD2
 getColumnCount	KEYWORD2
@@ -32,12 +32,12 @@ getColumn	KEYWORD2
 setColumn	KEYWORD2
 getRow	KEYWORD2
 setRow	KEYWORD2
-transform KEYWORD2
-update  KEYWORD2
+transform	KEYWORD2
+update	KEYWORD2
 wraparound	KEYWORD2
-getChar  KEYWORD2
-setChar  KEYWORD2
-setFont  KEYWORD2
+getChar	KEYWORD2
+setChar	KEYWORD2
+setFont	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords