### PR TITLE
Allow predefining MD_MAX72xx macros when invoking C++ compiler

### DIFF
--- a/src/MD_MAX72xx.cpp
+++ b/src/MD_MAX72xx.cpp
@@ -32,15 +32,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
 MD_MAX72XX::MD_MAX72XX(moduleType_t mod, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices):
-_dataPin(dataPin), _clkPin(clkPin), _csPin(csPin), _maxDevices(numDevices),
-_hardwareSPI(false), _updateEnabled(true)
+_dataPin(dataPin), _clkPin(clkPin), _csPin(csPin),
+_hardwareSPI(false), _maxDevices(numDevices), _updateEnabled(true)
 {
   setModuleParameters(mod);
 }
 
 MD_MAX72XX::MD_MAX72XX(moduleType_t mod, uint8_t csPin, uint8_t numDevices):
-_dataPin(0), _clkPin(0), _csPin(csPin), _maxDevices(numDevices),
-_hardwareSPI(true), _updateEnabled(true)
+_dataPin(0), _clkPin(0), _csPin(csPin),
+_hardwareSPI(true), _maxDevices(numDevices), _updateEnabled(true)
 {
   setModuleParameters(mod);
 }

--- a/src/MD_MAX72xx.cpp
+++ b/src/MD_MAX72xx.cpp
@@ -176,6 +176,9 @@ void MD_MAX72XX::controlLibrary(controlRequest_t mode, int value)
     case WRAPAROUND:
       _wrapAround = (value == ON);
       break;
+
+    default:
+      break;
   }
 }
 

--- a/src/MD_MAX72xx.h
+++ b/src/MD_MAX72xx.h
@@ -247,14 +247,24 @@ enough current for the number of connected modules.
  graphics some FLASH RAM can be saved by not including the code to process
  font data. The font file is stored in PROGMEM.
  */
+#ifndef USE_LOCAL_FONT
 #define USE_LOCAL_FONT 1
+#endif
 
 // Display parameter constants
 // Defined values that are used throughout the library to define physical limits
+#ifndef ROW_SIZE
 #define ROW_SIZE  8   ///< The size in pixels of a row in the device LED matrix array
+#endif
+#ifndef COL_SIZE
 #define COL_SIZE  8   ///< The size in pixels of a column in the device LED matrix array
+#endif
+#ifndef MAX_INTENSITY
 #define MAX_INTENSITY 0xf ///< The maximum intensity value that can be set for a LED array
+#endif
+#ifndef MAX_SCANLIMIT
 #define MAX_SCANLIMIT 7   ///< The maximum scan limit value that can be set for the devices
+#endif
 
 /**
  * Core object for the MD_MAX72XX library

--- a/src/MD_MAX72xx_font.cpp
+++ b/src/MD_MAX72xx_font.cpp
@@ -29,7 +29,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  * \file
  * \brief Implements font definition and methods
  */
-#define USE_NEW_FONT
+#ifndef USE_NEW_FONT
+#define USE_NEW_FONT 1
+#endif
 
 #if USE_LOCAL_FONT
 // Local font handling functions if the option is enabled
@@ -204,7 +206,7 @@ uint8_t MD_MAX72XX::setChar(uint16_t col, uint8_t c)
 // Standard font - variable spacing
 MD_MAX72XX::fontType_t PROGMEM _sysfont[] =
 {
-#ifdef USE_NEW_FONT
+#if USE_NEW_FONT
   'F', 1, 0, 255, 8,
   0,		// 0 - 'Empty Cell'
   5, 62, 91, 79, 91, 62,		// 1 - 'Sad Smiley'

--- a/src/MD_MAX72xx_font.cpp
+++ b/src/MD_MAX72xx_font.cpp
@@ -131,8 +131,8 @@ int16_t MD_MAX72XX::getFontCharOffset(uint8_t c)
     }
 
     PRINT(" searched offset ", offset);
-    return(offset);
   }
+  return(offset);
 }
 
 bool MD_MAX72XX::setFont(fontType_t *f)


### PR DESCRIPTION
I have surrounded the `#define`s that set the display parameters and the local font configuration in `#ifndef`/`#endif` directives.

That allows predefining these macros in a `Makefile` or the file `platformio.ini` (the PlatformIO project configuration file), for example:
```
-D USE_NEW_FONT=0
```

I have also fixed 3 compiler warnings.