### PR TITLE
Add possibility to mirror data on individual devices

### DIFF
--- a/src/MD_MAX72xx.h
+++ b/src/MD_MAX72xx.h
@@ -341,7 +341,8 @@ public:
     TFLR, ///< Transform Flip Left to Right
     TFUD, ///< Transform Flip Up to Down
     TRC,  ///< Transform Rotate Clockwise 90 degrees
-    TINV  ///< Transform INVert (pixels inverted)
+    TINV, ///< Transform INVert (pixels inverted)
+    TMLR  ///< Transform Mirror Left to Right
   };
 
   /**

--- a/src/MD_MAX72xx_buf.cpp
+++ b/src/MD_MAX72xx_buf.cpp
@@ -330,6 +330,7 @@ bool MD_MAX72XX::transformBuffer(uint8_t buf, transformType_t ttype)
     break;
 
   //--------------
+  case TMLR: // Transform Mirror Left to Right
   case TFLR: // Transform Flip Left to Right
     if (_hwDigRows)
     {

--- a/src/MD_MAX72xx_pix.cpp
+++ b/src/MD_MAX72xx_pix.cpp
@@ -236,6 +236,7 @@ bool MD_MAX72XX::transform(uint8_t startDev, uint8_t endDev, transformType_t tty
     case TFUD:  // Transform Flip Up to Down
     case TRC:   // Transform Rotate Clockwise
     case TINV:  // Transform INVert
+    case TMLR:  // Transform Mirror Left to Right
     for (uint8_t buf = startDev; buf <= endDev; buf++)
       transformBuffer(buf, ttype);
     break;


### PR DESCRIPTION
Currently, transform TFLR does *almost* the job but reverses devices and
whole device chain. On some devices, it is needed to simply reverse
individual devices. Add a transform define to select this
transformation only for individual devices.