### PR TITLE
remove SPI.h from includes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         uses: Legion2/download-release-action@v2.1.0
         with:
           repository:  MajicDesigns/MD_UISwitch
-          tag: '2.1.0'
+          tag: 'v2.1.0'
           path: libraries
       - name: Compile examples using Arduino Uno
         uses: pfeerick/arduino-builder-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,20 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1
+      # Intall libraries needed by the examples
       - name: Install MD_UISwitch lib
         uses: Legion2/download-release-action@v2.1.0
         with:
           repository:  MajicDesigns/MD_UISwitch
           tag: 'v2.1.0'
           path: libraries
+      - name: Install SdFat lib
+        uses: Legion2/download-release-action@v2.1.0
+        with:
+          repository:  greiman/SdFat
+          tag: '1.1.4'
+          path: libraries
+      # Build all examples in the examples folder
       - name: Compile examples using Arduino Uno
         uses: pfeerick/arduino-builder-action@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
         uses: ArminJo/arduino-test-compile@v2
         with:
           sketches-exclude: MD_MAX72XX_Message_ESP8266
-          required-libraries: MD_UISwitch,SdFat,SPI
+          required-libraries: MD_UISwitch,SdFat
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
         uses: ArminJo/arduino-test-compile@v2
         with:
           sketches-exclude: MD_MAX72XX_Message_ESP8266
-          required-libraries: SPI,MD_UISwitch,SdFat
+          required-libraries: MD_UISwitch,SdFat,SPI
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1
-      - name: Install libraries
+      - name: Install MD_UISwitch lib
         uses: Legion2/download-release-action@v2.1.0
         with:
-          repository: MajicDesigns/MD_UISwitch
-          tag: 2.1.0
+          repository:  MajicDesigns/MD_UISwitch
+          tag: '2.1.0'
           path: libraries
       - name: Compile examples using Arduino Uno
         uses: pfeerick/arduino-builder-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: build
+
+on: push
+
+jobs:
+  build:
+    name: build-examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+      - name: Compile examples using Arduino Uno
+        uses: pfeerick/arduino-builder-action@master
+        with:
+          board: "arduino:avr:uno"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v1
+      - name: Install libraries
+        uses: Legion2/download-release-action@v2.1.0
+        with:
+          repository: MajicDesigns/MD_UISwitch
+          tag: 2.1.0
+          path: libraries
       - name: Compile examples using Arduino Uno
         uses: pfeerick/arduino-builder-action@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
         uses: ArminJo/arduino-test-compile@v2
         with:
           sketches-exclude: MD_MAX72XX_Message_ESP8266
-          required-libraries: MD_UISwitch,SdFat
+          required-libraries: SPI,MD_UISwitch,SdFat
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,22 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v1
-      # Intall libraries needed by the examples
-      - name: Install MD_UISwitch lib
-        uses: Legion2/download-release-action@v2.1.0
+        uses: actions/checkout@v2
+      - name: Test compile for Arduino
+        uses: ArminJo/arduino-test-compile@v2
         with:
-          repository:  MajicDesigns/MD_UISwitch
-          tag: 'v2.1.0'
-          path: libraries
-      - name: Install SdFat lib
-        uses: Legion2/download-release-action@v2.1.0
-        with:
-          repository:  greiman/SdFat
-          tag: '1.1.4'
-          path: libraries
-      # Build all examples in the examples folder
-      - name: Compile examples using Arduino Uno
-        uses: pfeerick/arduino-builder-action@master
-        with:
-          board: "arduino:avr:uno"
+          sketches-exclude: MD_MAX72XX_Message_ESP8266
+          required-libraries: MD_UISwitch,SdFat
+

--- a/library.properties
+++ b/library.properties
@@ -7,5 +7,5 @@ paragraph= Allows the programmer to use the LED matrix as a pixel addressable di
 category=Device Control
 url=https://github.com/MajicDesigns/MD_MAX72XX
 architectures=*
-includes=MD_MAX72xx.h,SPI.h
+includes=MD_MAX72xx.h
 license=LGPL-2.1


### PR DESCRIPTION
SPI.h is not provided by this library. 
It may confuses the library resolver of arduino-cli by thinking we provide this header.