### PR TITLE
fix for Arduino on Mbed targets

### DIFF
--- a/src/MD_MAX72xx.cpp
+++ b/src/MD_MAX72xx.cpp
@@ -21,7 +21,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO)
 #include "mbed.h"
 #else
 #include <Arduino.h>
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 MD_MAX72XX::MD_MAX72XX(moduleType_t mod, uint8_t dataPin, uint8_t clkPin, uint8_t csPin, uint8_t numDevices):
 _dataPin(dataPin), _clkPin(clkPin), _csPin(csPin),
 _hardwareSPI(false), _maxDevices(numDevices), _updateEnabled(true)
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO)
 , _spi((PinName)dataPin, NC, (PinName)clkPin),
 _cs((PinName)csPin)
 #endif
@@ -50,7 +50,7 @@ _cs((PinName)csPin)
 MD_MAX72XX::MD_MAX72XX(moduleType_t mod, uint8_t csPin, uint8_t numDevices):
 _dataPin(0), _clkPin(0), _csPin(csPin),
 _hardwareSPI(true), _maxDevices(numDevices), _updateEnabled(true)
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO)
 , _spi(SPI_MOSI, NC, SPI_SCK),
 _cs((PinName)csPin)
 #endif
@@ -85,21 +85,21 @@ void MD_MAX72XX::begin(void)
   // initialize the SPI interface
   if (_hardwareSPI)
   {
-#ifndef __MBED__
+#ifdef ARDUINO
     PRINTS("\nHardware SPI");
     SPI.begin();
 #endif
   }
   else
   {
-#ifndef __MBED__
+#ifdef ARDUINO
     PRINTS("\nBitBang SPI")
     pinMode(_dataPin, OUTPUT);
     pinMode(_clkPin, OUTPUT);
 #endif
   }
 
-#ifndef __MBED__
+#ifdef ARDUINO
   // initialize our preferred CS pin (could be same as SS)
   pinMode(_csPin, OUTPUT);
   digitalWrite(_csPin, HIGH);
@@ -137,7 +137,7 @@ void MD_MAX72XX::begin(void)
 
 MD_MAX72XX::~MD_MAX72XX(void)
 {
-#ifndef __MBED__  
+#ifdef ARDUINO
   if (_hardwareSPI) SPI.end();  // reset SPI mode
 #endif
 
@@ -311,7 +311,7 @@ void MD_MAX72XX::spiClearBuffer(void)
 
 void MD_MAX72XX::spiSend()
 {
-#ifndef __MBED__
+#ifdef ARDUINO
   // initialize the SPI transaction
   if (_hardwareSPI)
     SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
@@ -335,7 +335,7 @@ void MD_MAX72XX::spiSend()
     SPI.endTransaction();
 #else
   _cs = 0;
-  volatile int n = _spi.write((const char*)_spiData, SPI_DATA_SIZE, nullptr, 0);
+  _spi.write((const char*)_spiData, SPI_DATA_SIZE, nullptr, 0);
   _cs = 1;
 #endif
 }

--- a/src/MD_MAX72xx.h
+++ b/src/MD_MAX72xx.h
@@ -5,7 +5,7 @@
  * \brief Main header file for the MD_MAX72xx library
  */
 
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO)
 #include "mbed.h"
 #define delay   ThisThread::sleep_for
 #ifndef PROGMEM
@@ -994,7 +994,7 @@ private:
   bool    _wrapAround;    // when shifting, wrap left to right and vice versa (circular buffer)
 
   // SPI interface data
-#ifdef __MBED__
+#if defined(__MBED__) && !defined(ARDUINO)
   SPI   _spi;           // Mbed SPI object
   DigitalOut _cs;
 #endif

--- a/src/MD_MAX72xx_buf.cpp
+++ b/src/MD_MAX72xx_buf.cpp
@@ -20,7 +20,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#ifndef __MBED__
+#ifdef ARDUINO 
 #include <Arduino.h>
 #endif
 #include "MD_MAX72xx.h"

--- a/src/MD_MAX72xx_font.cpp
+++ b/src/MD_MAX72xx_font.cpp
@@ -21,7 +21,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#ifndef __MBED__
+#ifdef ARDUINO 
 #include <Arduino.h>
 #endif
 #include "MD_MAX72xx.h"

--- a/src/MD_MAX72xx_pix.cpp
+++ b/src/MD_MAX72xx_pix.cpp
@@ -23,7 +23,7 @@ You should have received a copy of the GNU Lesser General Public
 License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
-#ifndef __MBED__
+#ifdef ARDUINO 
 #include <Arduino.h>
 #endif
 #include "MD_MAX72xx.h"


### PR DESCRIPTION
## Proposed changes
alternatives you considered, etc...These targets (Nano33 BLE, PortentaH7) are using Mbed as a base and a compatibility layer for Arduino. In this case, both platforms defines ```__MBED__``` and ```ARDUINO``` are set.
Fix for #38 

## Types of changes
What types of changes does your code introduce?
Put an `x` in the boxes that apply
[x] Bugfix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Your Environment
**Library Version:** 
3.2.4
**Arduino IDE version:** 
1.8.3
**Hardware model/type:** 
**OS and Version:** 
Windows10

## Checklist
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is a reminder of what we are expecting before merging your code.
[x] Code compiles correctly/with no errors
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I have added or extended necessary documentation (if appropriate)
[ ] Any dependent changes have been merged and published in downstream modules

Tested compiling for Nano, Uno, Nano33 BLE, PortentaH7, ESP82 Generic

## Further comments
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what 