### PR TITLE
Map physical position to buffer index

### DIFF
--- a/src/MD_MAX72xx.cpp
+++ b/src/MD_MAX72xx.cpp
@@ -59,7 +59,7 @@ _cs((PinName)csPin)
 }
 
 void MD_MAX72XX::setModuleParameters(moduleType_t mod)
-// Combinations not listed as tested have *probably* not 
+// Combinations not listed as tested have *probably* not
 // been tested and may not operate correctly.
 {
   _mod = mod;
@@ -68,7 +68,7 @@ void MD_MAX72XX::setModuleParameters(moduleType_t mod)
     case DR0CR0RR0_HW: _hwDigRows = false; _hwRevCols = false;  _hwRevRows = false; break;
     case DR0CR0RR1_HW: _hwDigRows = false; _hwRevCols = false;  _hwRevRows = true;  break;
     case DR0CR1RR0_HW: // same as GENERIC_HW, tested MC 9 March 2014
-    case GENERIC_HW:   _hwDigRows = false; _hwRevCols = true;  _hwRevRows = false;  break; 
+    case GENERIC_HW:   _hwDigRows = false; _hwRevCols = true;  _hwRevRows = false;  break;
     case DR0CR1RR1_HW: _hwDigRows = false; _hwRevCols = true;  _hwRevRows = true;   break;
     case DR1CR0RR0_HW: // same as FC16_HW, tested MC 23 Feb 2015
     case FC16_HW:      _hwDigRows = true;  _hwRevCols = false;  _hwRevRows = false; break;
@@ -113,6 +113,9 @@ void MD_MAX72XX::begin(void)
 
   _matrix = (deviceInfo_t *)malloc(sizeof(deviceInfo_t) * _maxDevices);
   _spiData = (uint8_t *)malloc(SPI_DATA_SIZE);
+
+  _deviceMap = (uint8_t *)malloc(_maxDevices);
+  for (uint8_t d = 0; d < _maxDevices; d++) _deviceMap[d] = d;
 
 #if USE_LOCAL_FONT
   setFont(_sysfont);
@@ -263,7 +266,7 @@ void MD_MAX72XX::flushBufferAll()
       {
         // put our device data into the buffer
         _spiData[SPI_OFFSET(dev, 0)] = OP_DIGIT0+i;
-        _spiData[SPI_OFFSET(dev, 1)] = _matrix[dev].dig[i];
+        _spiData[SPI_OFFSET(dev, 1)] = _matrix[_deviceMap[dev]].dig[i];
         bChange = true;
       }
     }
@@ -295,7 +298,7 @@ void MD_MAX72XX::flushBuffer(uint8_t buf)
 
       // put our device data into the buffer
       _spiData[SPI_OFFSET(buf, 0)] = OP_DIGIT0+i;
-      _spiData[SPI_OFFSET(buf, 1)] = _matrix[buf].dig[i];
+      _spiData[SPI_OFFSET(buf, 1)] = _matrix[_deviceMap[buf]].dig[i];
 
       spiSend();
     }

--- a/src/MD_MAX72xx.h
+++ b/src/MD_MAX72xx.h
@@ -438,7 +438,7 @@ public:
   /**
    * Initialize the object.
    *
-   * Initialize the object data. This needs to be called during setup() to initialize 
+   * Initialize the object data. This needs to be called during setup() to initialize
    * new data for the class that cannot be done during the object creation.
    *
    * The LED hardware is initialized to the middle intensity value, all rows showing,
@@ -518,14 +518,27 @@ public:
   /**
    * Set the type of hardware module being used.
    *
-   * This method changes the type of module being used in the application 
+   * This method changes the type of module being used in the application
    * during at run time.
    *
    * \param mod module type used in this application; one of the moduleType_t values.
    * \return No return data
    */
   void setModuleType(moduleType_t mod) { setModuleParameters(mod); };
-  
+
+  /**
+   * Update the device map
+   *
+   * This method updates the device map used to map the physical position of
+   * devices to buffer index. For example if the devices are ordered 3 2 1 0
+   * using a map of [3, 2, 1, 0] would map the buffer indexes to the physical
+   * location of the devices.
+   *
+   * \param dmap an array of the physical locations
+   * \return No return data
+   */
+  void setDeviceMap(const uint8_t* dmap) { memcpy(_deviceMap, dmap, _maxDevices); };
+
   /**
    * Set the Shift Data In callback function.
    *
@@ -918,7 +931,7 @@ public:
    * the nominated font (default or user defined). To specify a user defined
    * character set, pass the PROGMEM address of the font table. Passing a nullptr
    * resets the font table to the library default table.
-   * 
+   *
    * NOTE: This function is only available if the library defined value
    * USE_LOCAL_FONT is set to 1.
    *
@@ -931,7 +944,7 @@ public:
   * Get the maximum width character for the font.
   *
   * Returns the number of columns for the widest character in the currently
-  * selected font table. Useful to allocated buffers of the right size before 
+  * selected font table. Useful to allocated buffers of the right size before
   * loading characters from the font table.
   *
   * NOTE: This function is only available if the library defined value
@@ -944,7 +957,7 @@ public:
   /**
   * Get height of a character for the font.
   *
-  * Returns the number of rows specified as the height of a character in the 
+  * Returns the number of rows specified as the height of a character in the
   * currently selected font table.
   *
   * NOTE: This function is only available if the library defined value
@@ -957,7 +970,7 @@ public:
   /**
    * Get the pointer to current font table.
    *
-   * Returns the pointer to the current font table. Useful if user code needs 
+   * Returns the pointer to the current font table. Useful if user code needs
    * to replace the current font temporarily and then restore previous font.
    *
    * NOTE: This function is only available if the library defined value
@@ -981,6 +994,7 @@ private:
   bool _hwDigRows;    // MAX72xx digits are mapped to rows in on the matrix
   bool _hwRevCols;    // Normal orientation is col 0 on the right. Set to true if reversed
   bool _hwRevRows;    // Normal orientation is row 0 at the top. Set to true if reversed
+  uint8_t* _deviceMap;  // A map of physical device position to buffer index
 
   uint8_t _dataPin;     // DATA is shifted out of this pin ...
   uint8_t _clkPin;      // ... signaled by a CLOCK on this pin ...


### PR DESCRIPTION
Add the ability to map the physical location of the devices to the buffer index.

I have a display module that is constructed with the data in on the lefthand side and is wired in such a way that the individual devices are numbered 3 2 1 0 by the library. This makes it difficult to write to the display. This change adds a device map array allowing the physical location of the devices to be mapped to the buffer indexes.